### PR TITLE
Added FilteredChestHopper mod detection to add Hoppers as an inventory

### DIFF
--- a/UnlimitedStorage/Constants.cs
+++ b/UnlimitedStorage/Constants.cs
@@ -6,6 +6,8 @@ internal static class Constants
 
     public const string ChestsAnywhereId = "Pathoschild.ChestsAnywhere";
 
+    public const string FilteredChestHopper = "shivion.FilteredChestHopper";
+
     public const string ModEnabled = ModId + "/Enabled";
 
     public const string ModId = "furyx639.UnlimitedStorage";

--- a/UnlimitedStorage/Services/ConfigMenu.cs
+++ b/UnlimitedStorage/Services/ConfigMenu.cs
@@ -10,6 +10,7 @@ internal sealed class ConfigMenu
     private readonly IGenericModConfigMenuApi api = null!;
     private readonly GenericModConfigMenuIntegration gmcm;
     private readonly IManifest manifest;
+    private readonly IModHelper helper = null!;
 
     public ConfigMenu(IModHelper helper, IManifest manifest)
     {
@@ -21,6 +22,7 @@ internal sealed class ConfigMenu
         }
 
         this.api = this.gmcm.Api;
+        this.helper = helper;
         this.SetupMenu();
     }
 
@@ -70,7 +72,20 @@ internal sealed class ConfigMenu
         this.api.AddSectionTitle(this.manifest, I18n.ConfigOption_MakeUnlimited_Name);
         this.api.AddParagraph(this.manifest, I18n.ConfigOption_MakeUnlimited_Description);
 
-        foreach (var id in ConfigHelper.Default.EnabledIds)
+        
+        var EndabledIds = ConfigHelper.Default.EnabledIds;
+
+        // If the FilteredChestHopper mod is present, add hoppers as an option; otherwise remove them
+        if (this.helper.ModRegistry.IsLoaded(Constants.FilteredChestHopper))
+        {
+            EndabledIds.Add("275");
+        }
+        else
+        {
+            EndabledIds.Remove("275");
+        }
+
+        foreach (var id in EndabledIds)
         {
             if (!Game1.bigCraftableData.TryGetValue(id, out var data))
             {


### PR DESCRIPTION
Allows Unlimited Storage to detect if Filtered Chest Hoppers is installed, and adds it to the list of EnabledIDs if it is.

This is beneficial as Filtered Chest Hoppers adds an inventory to hoppers to use as a filter list allowing for more items to filter on, and therefor more compact operations