### PR TITLE
[Bug fix]: Fixed Junimo chests' mechanics break when using BigChestMenu

### DIFF
--- a/UnlimitedStorage/Services/ModPatches.cs
+++ b/UnlimitedStorage/Services/ModPatches.cs
@@ -16,6 +16,11 @@ internal static class ModPatches
     private static readonly string EmptySlot = int.MaxValue.ToString(CultureInfo.InvariantCulture);
     private static readonly Harmony Harmony = new(Constants.ModId);
 
+    /// <summary>Record the capacity of chests after method
+    /// <see cref="Chest.GetActualCapacity"/> called.
+    /// Mainly used to make compatibility to other mods.</summary>
+    private static int _actualCapacity;
+
     public static void Apply()
     {
         Log.Info("Applying Patches");
@@ -25,10 +30,6 @@ internal static class ModPatches
             _ = Harmony.Patch(
                 AccessTools.DeclaredMethod(typeof(Chest), nameof(Chest.GetActualCapacity)),
                 postfix: new HarmonyMethod(typeof(ModPatches), nameof(Chest_GetActualCapacity_postfix)));
-
-            _ = Harmony.Patch(
-                AccessTools.DeclaredPropertyGetter(typeof(Chest), nameof(Chest.SpecialChestType)),
-                postfix: new HarmonyMethod(typeof(ModPatches), nameof(Chest_SpecialChestType_postfix)));
 
             _ = Harmony.Patch(
                 AccessTools.DeclaredMethod(typeof(InventoryMenu), nameof(InventoryMenu.draw),
@@ -71,32 +72,14 @@ internal static class ModPatches
         if (Game1.bigCraftableData.TryGetValue(__instance.ItemId, out var data) &&
             data.CustomFields?.GetBool(Constants.ModEnabled) == true)
         {
+            _actualCapacity = ModState.Config.BigChestMenu ? 70 : __result;
             __result = Math.Max(
-                ModState.Config.BigChestMenu ? 70 : __result,
-                Math.Max(__result, __instance.GetItemsForPlayer().Count + 1));
+                _actualCapacity, Math.Max(__result, __instance.GetItemsForPlayer().Count + 1));
         }
     }
 
-    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Harmony")]
-    [SuppressMessage("ReSharper", "SuggestBaseTypeForParameter", Justification = "Harmony")]
-    private static void Chest_SpecialChestType_postfix(ref Chest.SpecialChestTypes __result)
-    {
-        if (ModState.Config.BigChestMenu &&
-            __result is Chest.SpecialChestTypes.None or Chest.SpecialChestTypes.JunimoChest)
-        {
-            __result = Chest.SpecialChestTypes.BigChest;
-        }
-    }
-
-    private static int GetActualCapacity(int capacity, object? context) =>
-        (context as Chest)?.SpecialChestType switch
-        {
-            Chest.SpecialChestTypes.MiniShippingBin or Chest.SpecialChestTypes.JunimoChest => 9,
-            Chest.SpecialChestTypes.Enricher => 1,
-            Chest.SpecialChestTypes.BigChest => 70,
-            not null => ModState.Config.BigChestMenu ? 70 : 36,
-            _ => capacity
-        };
+    private static int GetActualCapacity(int _) =>
+        ModState.Config.BigChestMenu ? 70 : _actualCapacity;
 
     private static IEnumerable<CodeInstruction>
         InventoryMenu_draw_transpiler(IEnumerable<CodeInstruction> instructions) =>
@@ -194,7 +177,6 @@ internal static class ModPatches
                 matcher
                     .Advance(1)
                     .InsertAndAdvance(
-                        new CodeInstruction(OpCodes.Ldarg_S, (short)16),
                         CodeInstruction.Call(typeof(ModPatches), nameof(GetActualCapacity)))
             )
             .InstructionEnumeration();


### PR DESCRIPTION
Hello, I'm also a mod developer, and one of my users reported an issue regarding an incompatibility between our mods. I investigated the problem and identified a couple of areas in your patches that could be improved:

1. **Patch method `Chest.SpecialChestType`**: This patch presents some risks as it can interfere with game mechanics. Specifically, I found that it causes Junimo chests to malfunction when the `BigChestMenu` feature is enabled. To resolve this, I've removed this patch entirely.

2. **Patch method `Chest.GetActualCapacity`**: The current implementation operates as a post-fix patch, which can create compatibility issues when other mods use prefix patches on the same method (such as my mod [BiggerContainer](https://www.nexusmods.com/stardewvalley/mods/35905) and Entoarox's [Bigger Fridges](https://www.nexusmods.com/stardewvalley/mods/21678)). To address this, I've introduced a new private field to cache the method's original return value and restructured the patching approach to ensure better compatibility with other mods.

These changes should improve stability and compatibility while maintaining the intended functionality of your mod.